### PR TITLE
Test deep association queries in Doctrine2::seeInRepository

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "white-october/pagerfanta-bundle": "^1.1"
     },
     "require-dev": {
-        "codeception/codeception": "2.5.x-dev",
+        "codeception/codeception": "3.0.x-dev",
         "friendsofphp/php-cs-fixer": "^2.7",
         "symfony/browser-kit": "^4.0",
         "symfony/css-selector": "^4.0",

--- a/tests/functional/CommentCest.php
+++ b/tests/functional/CommentCest.php
@@ -21,7 +21,31 @@ class CommentCest
         $I->submitForm('#post-add-comment > form', []);
         $I->seeCurrentRouteIs('blog_post');
         $I->see('Hi, Symfony!');
-        $I->seeInRepository(Comment::class, ['content' => 'Hi, Symfony!']);
+        // This particular assertion is a bit of overkill, but it also serves as a testcase
+        // of `seeInRepository` method with complex associations. Here is how this assertion
+        // translates to English:
+        //
+        //   * I see a comment entity with content equal to 'Hi, Symfony!'
+        //   * and 'author' association points to a user entity with username equal to 'john_user'
+        //   ** note: john_user is one who created the comment, as it is used in login
+        //      procedure above
+        //   * and 'post' association points to a post entity which...
+        //   * ...has an associated comment entity which...
+        //   * ...has same content and author with same username.
+        $I->seeInRepository(Comment::class, [
+            'content' => 'Hi, Symfony!',
+            'author' => [
+                'username' => 'john_user',
+            ],
+            'post' => [
+                'comments' => [
+                    'content' => 'Hi, Symfony!',
+                    'author' => [
+                        'username' => 'john_user'
+                    ]
+                ]
+            ]
+        ]);
     }
 
 }


### PR DESCRIPTION
This pull request adds a test case for the fix discussed in Codeception/Codeception#5542.