### PR TITLE
2.1 Use Symfony module functional suite

### DIFF
--- a/src/AppBundle/test/functional.suite.yml
+++ b/src/AppBundle/test/functional.suite.yml
@@ -7,11 +7,11 @@
 class_name: FunctionalTester
 modules:
     enabled:
-        - Symfony2:
+        - Symfony:
             app_path: '../../app'
             var_path: '../../app'
         - Doctrine2:
-            depends: Symfony2
+            depends: Symfony
         - \AcmeBundle\Helper\Functional
         - Asserts
         - Sequence


### PR DESCRIPTION
Because Symfony2 alias was removed in Codeception 4.0